### PR TITLE
Facia-purger cloudformation template and upload to riffraff

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ jdk: oraclejdk8
 sudo: false
 branches:
   only:
-  - facia-purger-cloudform
+  - master
 cache:
   directories:
   - $HOME/.sbt/0.13

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: scala
 scala:
 - 2.11.8
 jdk: oraclejdk8
+sudo: false
 branches:
   only:
   - facia-purger-cloudform

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: scala
+scala:
+- 2.11.8
+jdk: oraclejdk8
+branches:
+  only:
+  - master
+cache:
+  directories:
+  - $HOME/.sbt/0.13
+  - $HOME/.sbt/boot/scala*
+  - $HOME/.sbt/cache
+  - $HOME/.sbt/launchers
+  - $HOME/.ivy2
+before_cache:
+- du -h -d 1 $HOME/.ivy2/
+- du -h -d 2 $HOME/.sbt/
+- find $HOME/.sbt -name "*.lock" -type f -delete
+- find $HOME/.ivy2/cache -name "ivydata-*.properties" -type f -delete
+env:
+  matrix:
+  - TRAVIS_NESTED_LAMBDA=facia-purger
+  global:
+  - secure: O/2qdhemDAKuScBI6+AHLNSh9C2yZIIq27VifgUj+x+89IQUI+Sy7Tz2hzvlrM9vXwLkqQgfReS8bZuOg1nHeQOt8jA/Mb06xvqe86nHpviy4DR3f1Pfqkm3lkAiv2eRyvivjfRicV96Fij3JmbTvtvk4LumnogYaYILwGCXfiiFiCpJMmgsOIZAQYMvTBfck2zvxvRZGReewWGSBsLkyrxycETXFNcNQwF/RWBb9noZkOf8O8g2vySB/aREhVd5xGtxDAgZEnoW/alcBJh4kp0J3L2SXVUMmPhLfH4cDkBjZv1biHeJCE2js89FD+mCPak83v5FL5JE87MR2peLu1bheMlRcukyewCr1CN5gjScyRA4zgsiZkSz1fYiPI9Z2MMLUNUTh/yAM7Kmw0PHd3v1LzBxGVV87WAHJhsUkGT+CKoJcpkhHlx1ErCeV8Ly2L5xtmwpc4zuGytOBWyPuDwKajYc2z/kO7+1aJTxNELinEWcJWJySKGTLB6oj50EmO7VWgv1GL43OL8BvsFhwDvu5Jml4KiHoxdmzhswLkTbirkFm3bn77HbNgfNNxRfmig9sDrYekMKrLOrf9AdPCdZB/oDOhArvgp9ExxKHvOux91n21Q0rkurl9GYJr7qIm1Ll7+jccIjh6ID/j1uSGWpdCBPlgFX7jVNzATumfs=
+  - secure: aVGHnA/1Or5hclfppfj/3/NFYeE6RqGvO6XxQquCYbtWSOC4m/WMqbRd5X+RrNvbCPu5jtATe+4CiGWMwkuVbsKtnGN4wNBoORs8NlabqlFevTZJNdIbcH11RNJuFzgAwh3HYZklndUjYFVPAEEgJUWz/Y4chz+FEbBVimsA2V5JZFEXkuKNTuA1TpFdxF7K9gQrZEMuTO5U5N9JjjVUOFdfQOG90aU9eEWpFImHBs5ueieyTAnH48fsXrB8ZkPnPg6mbd/noSHPwAIXoQ+LgS/Fzj415i5MyGY3Uys6G4/ohSscWXqqIP45i/sUAs8yrsC+WsRXaANjcolt4kO4ySfyg4dotIOZkhnuPvJMmf0XSWje0smYD0wRkcGCkwGlRMmf3HmDuFHE+8mOBFxNo7YyeoegEt97tfUzq7VWm9djhIj/n52pRWg8PdGRHVtrfSGXSBF5bo9nf0k25Oxg4WGLpFDwrp6GCCEJUDt3K/HwLa1SmcYCRkDUlD351nccOrah/DxUbM/0lwWRe7BtXYCQ8Z+WpZwhHlPFc0GqX4unf2d/TF+BuZL4gW+5aYEZUz9Z2UvVUHXdUQtpCe/NP2uYv6cbH231OylhQpWaK+Q/E9NIcnaJcHWydSyTw1mM5GNL99XVAA7MTgzMDbYPiwPa/8HWvBsdxkFEwDMT+PA=
+script: cd $TRAVIS_NESTED_LAMBDA && sbt riffRaffBuildIdentifier clean test riffRaffUpload

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ scala:
 jdk: oraclejdk8
 branches:
   only:
-  - master
+  - facia-purger-cloudform
 cache:
   directories:
   - $HOME/.sbt/0.13

--- a/facia-purger/README.md
+++ b/facia-purger/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://travis-ci.org/guardian/frontend-lambda.svg?branch=master)](https://travis-ci.org/guardian/frontend-lambda)
+
 # facia-purger
 
 facia-purger is a lambda for listening to events from the fapi/pressed S3 objects in order to purge fastly when an object is changed

--- a/facia-purger/build.sbt
+++ b/facia-purger/build.sbt
@@ -1,6 +1,6 @@
 name := "facia-purger"
 
-version := "1.0"
+version := "1.0.0"
 
 scalaVersion := "2.11.8"
 
@@ -20,9 +20,14 @@ libraryDependencies ++= Seq(
 
 enablePlugins(RiffRaffArtifact, UniversalPlugin)
 
-riffRaffPackageType := (packageZipTarball in Universal).value
+packageName in Universal := normalizedName.value
+topLevelDirectory in Universal := Some(normalizedName.value)
 
+riffRaffPackageType := (packageBin in Universal).value
 def env(key: String): Option[String] = Option(System.getenv(key))
 riffRaffBuildIdentifier := env("TRAVIS_BUILD_NUMBER").getOrElse("DEV")
+riffRaffManifestBranch := env("TRAVIS_BRANCH").getOrElse(git.gitCurrentBranch.value)
+riffRaffManifestProjectName := "dotcom:lambda:facia-purger"
+
 riffRaffUploadArtifactBucket := Option("riffraff-artifact")
 riffRaffUploadManifestBucket := Option("riffraff-builds")

--- a/facia-purger/build.sbt
+++ b/facia-purger/build.sbt
@@ -17,3 +17,12 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "2.2.2" % "test",
   "org.mockito" % "mockito-all" % "1.9.5" % "test"
 )
+
+enablePlugins(RiffRaffArtifact, UniversalPlugin)
+
+riffRaffPackageType := (packageZipTarball in Universal).value
+
+def env(key: String): Option[String] = Option(System.getenv(key))
+riffRaffBuildIdentifier := env("TRAVIS_BUILD_NUMBER").getOrElse("DEV")
+riffRaffUploadArtifactBucket := Option("riffraff-artifact")
+riffRaffUploadManifestBucket := Option("riffraff-builds")

--- a/facia-purger/build.sbt
+++ b/facia-purger/build.sbt
@@ -18,16 +18,16 @@ libraryDependencies ++= Seq(
   "org.mockito" % "mockito-all" % "1.9.5" % "test"
 )
 
-enablePlugins(RiffRaffArtifact, UniversalPlugin)
-
-packageName in Universal := normalizedName.value
-topLevelDirectory in Universal := Some(normalizedName.value)
-
-riffRaffPackageType := (packageBin in Universal).value
 def env(key: String): Option[String] = Option(System.getenv(key))
-riffRaffBuildIdentifier := env("TRAVIS_BUILD_NUMBER").getOrElse("DEV")
-riffRaffManifestBranch := env("TRAVIS_BRANCH").getOrElse(git.gitCurrentBranch.value)
-riffRaffManifestProjectName := "dotcom:lambda:facia-purger"
 
-riffRaffUploadArtifactBucket := Option("riffraff-artifact")
-riffRaffUploadManifestBucket := Option("riffraff-builds")
+lazy val root = (project in file("."))
+  .enablePlugins(RiffRaffArtifact)
+  .settings(
+    assemblyJarName := normalizedName.value + ".jar",
+    riffRaffPackageType := assembly.value,
+    riffRaffBuildIdentifier := env("TRAVIS_BUILD_NUMBER").getOrElse("DEV"),
+    riffRaffManifestBranch := env("TRAVIS_BRANCH").getOrElse(git.gitCurrentBranch.value),
+    riffRaffManifestProjectName := s"dotcom:lambda:${normalizedName.value}",
+    riffRaffUploadArtifactBucket := Option("riffraff-artifact"),
+    riffRaffUploadManifestBucket := Option("riffraff-builds")
+)

--- a/facia-purger/build.sbt
+++ b/facia-purger/build.sbt
@@ -1,7 +1,5 @@
 name := "facia-purger"
 
-version := "1.0.0"
-
 scalaVersion := "2.11.8"
 
 organization := "com.gu"

--- a/facia-purger/cloudformation/cloudformation.json
+++ b/facia-purger/cloudformation/cloudformation.json
@@ -1,0 +1,121 @@
+{
+  "AWSTemplateFormatVersion": "2010-09-09",
+  "Description": "Facia purger lambda",
+  "Parameters": {
+    "LambdaName": {
+      "Description": "Lambda name",
+      "Type": "String",
+      "Default": "facia-purger"
+    },
+    "Stage": {
+      "Description": "Stage name",
+      "Type": "String",
+      "AllowedValues": [
+        "CODE",
+        "PROD"
+      ],
+      "Default": "CODE"
+    },
+    "DeployBucket": {
+      "Description": "Bucket where RiffRaff uploads artifacts on deploy",
+      "Type": "String"
+    }
+  },
+  "Resources": {
+    "ExecutionRole": {
+      "Type": "AWS::IAM::Role",
+      "Properties": {
+        "AssumeRolePolicyDocument": {
+          "Statement": [
+            {
+              "Effect": "Allow",
+              "Principal": {
+                "Service": [
+                  "lambda.amazonaws.com"
+                ]
+              },
+              "Action": "sts:AssumeRole"
+            }
+          ]
+        },
+        "Path": "/",
+        "Policies": [
+          {
+            "PolicyName": "logs",
+            "PolicyDocument": {
+              "Statement": {
+                "Effect": "Allow",
+                "Action": [
+                  "logs:CreateLogGroup",
+                  "logs:CreateLogStream",
+                  "logs:PutLogEvents"
+                ],
+                "Resource": "arn:aws:logs:*:*:*"
+              }
+            }
+          },
+          {
+            "PolicyName": "lambda",
+            "PolicyDocument": {
+              "Statement": {
+                "Effect": "Allow",
+                "Action": [
+                  "lambda:InvokeFunction"
+                ],
+                "Resource": "*"
+              }
+            }
+          },
+          {
+            "PolicyName": "s3",
+            "PolicyDocument": {
+              "Statement": {
+                "Effect": "Allow",
+                "Action": [
+                  "s3:GetObject"
+                ],
+                "Resource": "arn:aws:s3:::aws-frontend-store/*"
+              }
+            }
+          }
+        ]
+      }
+    },
+    "Lambda": {
+      "Type": "AWS::Lambda::Function",
+      "Properties": {
+        "Code": {
+          "S3Bucket": {
+            "Ref": "DeployBucket"
+          },
+          "S3Key": {
+            "Fn::Join": [
+              "/",
+              [
+                { "Ref": "Stage" },
+                "lambda",
+                {
+                  "Fn::Join": [
+                    "",
+                    [ { "Ref": "LambdaName" }, ".jar"]
+                  ]
+                }
+              ]
+            ]
+          }
+        },
+        "Description": "Purge fastly after a facia change event from an S3 bucket",
+        "Handler": "com.gu.purge.facia.Lambda",
+        "MemorySize": 256,
+        "Role": {
+          "Fn::GetAtt": [
+            "ExecutionRole",
+            "Arn"
+          ]
+        },
+        "Runtime": "java8",
+        "Timeout": 20
+      }
+    }
+  }
+}

--- a/facia-purger/project/plugins.sbt
+++ b/facia-purger/project/plugins.sbt
@@ -4,4 +4,4 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.6")
-addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")

--- a/facia-purger/project/plugins.sbt
+++ b/facia-purger/project/plugins.sbt
@@ -2,3 +2,6 @@ logLevel := Level.Warn
 
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
+
+addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.6")
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.1.1")

--- a/facia-purger/project/plugins.sbt
+++ b/facia-purger/project/plugins.sbt
@@ -4,4 +4,3 @@ addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")
 addSbtPlugin("org.scalariform" % "sbt-scalariform" % "1.6.0")
 
 addSbtPlugin("com.gu" % "sbt-riffraff-artifact" % "0.8.6")
-addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.3")

--- a/facia-purger/src/main/scala/com/gu/purge/facia/FrontsS3PathParser.scala
+++ b/facia-purger/src/main/scala/com/gu/purge/facia/FrontsS3PathParser.scala
@@ -4,8 +4,7 @@ import org.parboiled2.{ Parser, ParserInput }
 
 import scala.util.Success
 
-// /aws-frontend-store/CODE/frontsapi/pressed/live/au/fapi/pressed.json
-class ParseS3Path(stage: String, val input: ParserInput) extends Parser with Logging {
+class FrontsS3PathParser(stage: String, val input: ParserInput) extends Parser with Logging {
   def prefix = rule { s"$stage/frontsapi/pressed/live/" }
   val suffix = "/fapi/pressed.json"
 

--- a/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
+++ b/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
@@ -17,10 +17,10 @@ class Lambda() extends RequestHandler[S3Event, Boolean] with Logging {
     log.debug(s"Facia-purger lambda starting up")
     val config = Config.load(stage)
 
-    processEvent(event, config)
+    processS3Event(event, config)
   }
 
-  def processEvent(event: S3Event, config: Config) = {
+  def processS3Event(event: S3Event, config: Config) = {
     val entities: List[S3Entity] = event.getRecords.asScala.map(_.getS3).toList
 
     log.debug(s"Processing ${entities.size} updated entities ...")

--- a/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
+++ b/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
@@ -26,7 +26,7 @@ class Lambda() extends RequestHandler[S3Event, Boolean] with Logging {
     log.debug(s"Processing ${entities.size} updated entities ...")
 
     entities.forall { entity =>
-      new ParseS3Path(stage, entity.getObject.getKey)
+      new FrontsS3PathParser(stage, entity.getObject.getKey)
         .run()
         .exists(sendPurgeRequest(_, config))
     }

--- a/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
+++ b/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
@@ -17,10 +17,10 @@ class Lambda() extends RequestHandler[S3Event, Boolean] with Logging {
     log.debug(s"Facia-purger lambda starting up")
     val config = Config.load(stage)
 
-    processEntities(event, config)
+    processEvent(event, config)
   }
 
-  def processEntities(event: S3Event, config: Config) = {
+  def processEvent(event: S3Event, config: Config) = {
     val entities: List[S3Entity] = event.getRecords.asScala.map(_.getS3).toList
 
     log.debug(s"Processing ${entities.size} updated entities ...")

--- a/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
+++ b/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
@@ -26,7 +26,9 @@ class Lambda() extends RequestHandler[S3Event, Boolean] with Logging {
     log.debug(s"Processing ${entities.size} updated entities ...")
 
     entities.forall { entity =>
-      new ParseS3Path(stage, entity.getObject.getKey).run().map(sendPurgeRequest(_, config)).isDefined
+      new ParseS3Path(stage, entity.getObject.getKey)
+        .run()
+        .exists(sendPurgeRequest(_, config))
     }
   }
 
@@ -57,7 +59,7 @@ class Lambda() extends RequestHandler[S3Event, Boolean] with Logging {
       response.code == 200
     } else {
       log.warn(s"Didn't sent purge request for content with ID [$contentId].")
-      false
+      true
     }
   }
 

--- a/facia-purger/src/test/scala/com/gu/purge/facia/FrontsS3PathParserTest.scala
+++ b/facia-purger/src/test/scala/com/gu/purge/facia/FrontsS3PathParserTest.scala
@@ -2,7 +2,7 @@ package com.gu.purge.facia
 
 import org.scalatest.{ FlatSpec, Matchers }
 
-class ParseS3PathTest extends FlatSpec with Matchers {
+class FrontsS3PathParserTest extends FlatSpec with Matchers {
 
   "S3 Path Parser" should "parse a front name without a slash" in {
     new FrontsS3PathParser("CODE", "CODE/frontsapi/pressed/live/au/fapi/pressed.json").run() should be(Some("au"))

--- a/facia-purger/src/test/scala/com/gu/purge/facia/LambdaTest.scala
+++ b/facia-purger/src/test/scala/com/gu/purge/facia/LambdaTest.scala
@@ -23,6 +23,6 @@ class LambdaTest extends FlatSpec {
   lambda.stage = "DEV"
 
   "The lambda" should "complete and return true given a valid key" in {
-    lambda.processEvent(new S3Event(List[S3EventNotificationRecord](record).asJava), mockConfig) should be(true)
+    lambda.processS3Event(new S3Event(List[S3EventNotificationRecord](record).asJava), mockConfig) should be(true)
   }
 }

--- a/facia-purger/src/test/scala/com/gu/purge/facia/LambdaTest.scala
+++ b/facia-purger/src/test/scala/com/gu/purge/facia/LambdaTest.scala
@@ -23,6 +23,6 @@ class LambdaTest extends FlatSpec {
   lambda.stage = "DEV"
 
   "The lambda" should "complete and return true given a valid key" in {
-    lambda.processEntities(new S3Event(List[S3EventNotificationRecord](record).asJava), mockConfig) should be(true)
+    lambda.processEvent(new S3Event(List[S3EventNotificationRecord](record).asJava), mockConfig) should be(true)
   }
 }

--- a/facia-purger/src/test/scala/com/gu/purge/facia/LambdaTest.scala
+++ b/facia-purger/src/test/scala/com/gu/purge/facia/LambdaTest.scala
@@ -18,11 +18,20 @@ class LambdaTest extends FlatSpec {
   val s3 = new S3Entity("l", bucket, obj, "q")
   val record: S3EventNotificationRecord = new S3EventNotificationRecord("w", "e", "r", "2010-06-30T01:20+02:00", "y", req, resp, s3, user)
 
+  val invalidKey = "NOTDEV/frontsapy/prossed/dead/au/capi/prossed.yml"
+  val invalidObj = new S3ObjectEntity(invalidKey, 0L, "j", "k")
+  val invalidS3 = new S3Entity("l", bucket, invalidObj, "q")
+  val invalidRecord: S3EventNotificationRecord = new S3EventNotificationRecord("w", "e", "r", "2010-06-30T01:20+02:00", "y", req, resp, invalidS3, user)
+
   val mockConfig = Config("serviceId", "apiKey")
   val lambda = new Lambda()
   lambda.stage = "DEV"
 
-  "The lambda" should "complete and return true given a valid key" in {
-    lambda.processS3Event(new S3Event(List[S3EventNotificationRecord](record).asJava), mockConfig) should be(true)
+  "lambda processS3Event" should "complete and return true given a valid key" in {
+    lambda.processS3Event(new S3Event(List[S3EventNotificationRecord](record).asJava), mockConfig) should be (true)
+  }
+
+  it should "return false given an invalid key" in {
+    lambda.processS3Event(new S3Event(List[S3EventNotificationRecord](invalidRecord).asJava), mockConfig) should be (false)
   }
 }

--- a/facia-purger/src/test/scala/com/gu/purge/facia/LambdaTest.scala
+++ b/facia-purger/src/test/scala/com/gu/purge/facia/LambdaTest.scala
@@ -1,15 +1,13 @@
 package com.gu.purge.facia
 
-import com.amazonaws.services.lambda.runtime.Context
 import com.amazonaws.services.lambda.runtime.events.S3Event
 import com.amazonaws.services.s3.event.S3EventNotification._
 
 import scala.collection.JavaConverters._
 import org.scalatest.FlatSpec
-import org.scalatest.mock.MockitoSugar
 import org.scalatest.Matchers._
 
-class LambdaTest extends FlatSpec with MockitoSugar {
+class LambdaTest extends FlatSpec {
 
   val key = "DEV/frontsapi/pressed/live/au/fapi/pressed.json"
   val req = new RequestParametersEntity("a")
@@ -20,12 +18,11 @@ class LambdaTest extends FlatSpec with MockitoSugar {
   val s3 = new S3Entity("l", bucket, obj, "q")
   val record: S3EventNotificationRecord = new S3EventNotificationRecord("w", "e", "r", "2010-06-30T01:20+02:00", "y", req, resp, s3, user)
 
-  val mockContext = mock[Context]
+  val mockConfig = Config("serviceId", "apiKey")
   val lambda = new Lambda()
   lambda.stage = "DEV"
 
   "The lambda" should "complete and return true given a valid key" in {
-    lambda.handleRequest(new S3Event(List[S3EventNotificationRecord](record).asJava), mockContext) should be(true)
+    lambda.processEntities(new S3Event(List[S3EventNotificationRecord](record).asJava), mockConfig) should be(true)
   }
-
 }

--- a/facia-purger/src/test/scala/com/gu/purge/facia/ParseS3PathTest.scala
+++ b/facia-purger/src/test/scala/com/gu/purge/facia/ParseS3PathTest.scala
@@ -5,15 +5,15 @@ import org.scalatest.{ FlatSpec, Matchers }
 class ParseS3PathTest extends FlatSpec with Matchers {
 
   "S3 Path Parser" should "parse a front name without a slash" in {
-    new ParseS3Path("CODE", "CODE/frontsapi/pressed/live/au/fapi/pressed.json").run() should be(Some("au"))
+    new FrontsS3PathParser("CODE", "CODE/frontsapi/pressed/live/au/fapi/pressed.json").run() should be(Some("au"))
   }
 
   it should "parse a front name with a slash" in {
-    new ParseS3Path("DEV", "DEV/frontsapi/pressed/live/au/sport/fapi/pressed.json").run() should be(Some("au/sport"))
+    new FrontsS3PathParser("DEV", "DEV/frontsapi/pressed/live/au/sport/fapi/pressed.json").run() should be(Some("au/sport"))
   }
 
   it should "not parse when no front name is given" in {
-    new ParseS3Path("PROD", "PROD/frontsapi/pressed/live/fapi/pressed.json").run() should be(None)
+    new FrontsS3PathParser("PROD", "PROD/frontsapi/pressed/live/fapi/pressed.json").run() should be(None)
   }
 
 }


### PR DESCRIPTION
This PR adds travis builds which auto-upload to riffraff on success, along with a cloudformation template.

A deploy.json to be referenced by riffraff is not included because it needs to refer to (auto-generated) names once the stack has been created in AWS.  This will follow shortly.

@TBonnin @johnduffell