### PR TITLE
Add invocation and error alarms to facia-purger

### DIFF
--- a/facia-purger/cloudformation/cloudformation.json
+++ b/facia-purger/cloudformation/cloudformation.json
@@ -20,7 +20,7 @@
       "Description": "Bucket where RiffRaff uploads artifacts on deploy",
       "Type": "String"
     },
-    "NotificationRecipient": {
+    "EmailRecipient": {
       "Description": "The email address to send alarm notifications to",
       "Type": "String"
     }
@@ -127,16 +127,13 @@
       "Properties": {
         "Subscription": [ {
           "Protocol": "email",
-          "Endpoint": { "Ref": "NotificationRecipient" }
+          "Endpoint": { "Ref": "EmailRecipient" }
         } ]
       }
     },
     "InvocationAlarm": {
       "Type": "AWS::CloudWatch::Alarm",
       "Properties": {
-        "AlarmActions": [
-          { "Ref": "NotificationTopic" }
-        ],
         "InsufficientDataActions": [
           { "Ref": "NotificationTopic" }
         ],
@@ -153,7 +150,7 @@
         "Namespace": "AWS/Lambda",
         "Period": "3600",
         "Statistic": "Sum",
-        "Threshold": "1",
+        "Threshold": "0",
         "Unit": "Count"
       }
     },

--- a/facia-purger/cloudformation/cloudformation.json
+++ b/facia-purger/cloudformation/cloudformation.json
@@ -133,8 +133,11 @@
         "AlarmActions": [
           { "Ref": "NotificationTopic" }
         ],
-        "AlarmDescription": "Notify topic if there are no invocations over last 5 minutes",
-        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "InsufficientDataActions": [
+          { "Ref": "NotificationTopic" }
+        ],
+        "AlarmDescription": "Notify if there are less than 5 invocations over last 5 minutes or there is insufficient data (i.e. no invocations)",
+        "ComparisonOperator": "LessThanThreshold",
         "Dimensions": [
           {
             "Name": "FunctionName",
@@ -146,7 +149,7 @@
         "Namespace": "AWS/Lambda",
         "Period": "300",
         "Statistic": "Sum",
-        "Threshold": "0",
+        "Threshold": "5",
         "Unit": "Count"
       }
     },
@@ -156,7 +159,7 @@
         "AlarmActions": [
           { "Ref": "NotificationTopic" }
         ],
-        "AlarmDescription": "Notify topic if there are more than 20 errors over last 5 minutes",
+        "AlarmDescription": "Notify if there are more than 20 errors over last 5 minutes",
         "ComparisonOperator": "GreaterThanOrEqualToThreshold",
         "Dimensions": [
           {

--- a/facia-purger/cloudformation/cloudformation.json
+++ b/facia-purger/cloudformation/cloudformation.json
@@ -19,6 +19,10 @@
     "DeployBucket": {
       "Description": "Bucket where RiffRaff uploads artifacts on deploy",
       "Type": "String"
+    },
+    "NotificationRecipient": {
+      "Description": "The email address to send alarm notifications to",
+      "Type": "String"
     }
   },
   "Resources": {
@@ -123,7 +127,7 @@
       "Properties": {
         "Subscription": [ {
           "Protocol": "email",
-          "Endpoint": "dotcom.platform@guardian.co.uk"
+          "Endpoint": { "Ref": "NotificationRecipient" }
         } ]
       }
     },
@@ -137,7 +141,7 @@
           { "Ref": "NotificationTopic" }
         ],
         "AlarmDescription": "Notify if there are less than 5 invocations over last 5 minutes or there is insufficient data (i.e. no invocations)",
-        "ComparisonOperator": "LessThanThreshold",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
         "Dimensions": [
           {
             "Name": "FunctionName",
@@ -147,9 +151,9 @@
         "EvaluationPeriods": "1",
         "MetricName": "Invocations",
         "Namespace": "AWS/Lambda",
-        "Period": "300",
+        "Period": "3600",
         "Statistic": "Sum",
-        "Threshold": "5",
+        "Threshold": "1",
         "Unit": "Count"
       }
     },

--- a/facia-purger/cloudformation/cloudformation.json
+++ b/facia-purger/cloudformation/cloudformation.json
@@ -115,7 +115,62 @@
           ]
         },
         "Runtime": "java8",
-        "Timeout": 20
+        "Timeout": 30
+      }
+    },
+    "NotificationTopic": {
+      "Type": "AWS::SNS::Topic",
+      "Properties": {
+        "Subscription": [ {
+          "Protocol": "email",
+          "Endpoint": "dotcom.platform@guardian.co.uk"
+        } ]
+      }
+    },
+    "InvocationAlarm": {
+      "Type": "AWS::CloudWatch::Alarm",
+      "Properties": {
+        "AlarmActions": [
+          { "Ref": "NotificationTopic" }
+        ],
+        "AlarmDescription": "Notify topic if there are no invocations over last 5 minutes",
+        "ComparisonOperator": "LessThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": { "Ref": "Lambda" }
+          }
+        ],
+        "EvaluationPeriods": "1",
+        "MetricName": "Invocations",
+        "Namespace": "AWS/Lambda",
+        "Period": "300",
+        "Statistic": "Sum",
+        "Threshold": "0",
+        "Unit": "Count"
+      }
+    },
+    "ErrorAlarm": {
+      "Type" : "AWS::CloudWatch::Alarm",
+      "Properties": {
+        "AlarmActions": [
+          { "Ref": "NotificationTopic" }
+        ],
+        "AlarmDescription": "Notify topic if there are more than 20 errors over last 5 minutes",
+        "ComparisonOperator": "GreaterThanOrEqualToThreshold",
+        "Dimensions": [
+          {
+            "Name": "FunctionName",
+            "Value": { "Ref": "Lambda" }
+          }
+        ],
+        "EvaluationPeriods": "1",
+        "MetricName": "Errors",
+        "Namespace": "AWS/Lambda",
+        "Period": "300",
+        "Statistic": "Sum",
+        "Threshold": "20",
+        "Unit": "Count"
       }
     }
   }


### PR DESCRIPTION
This adds 2 alarms to the cloudformation template:

1. An invocation alarm which notifies a topic if there are less than 5 invocations of the lambda function in a 5 minute period (we would expect at least 5 a minute, just for the network fronts).  Since zero values (i.e. no invocations) are no actually sent to cloudwatch we also notify the same topic if this alarm goes into insufficient data state.

2. An error alarm which notifies a topic if there are more than 20 errors in a 5 minute period.  This might be triggered by consistent timeouts on the function for example.

All notifications go to dotcom.platform@guardian.co.uk.

Have also bumped the timeout for the function itself, just to be on the safer side.

@johnduffell @TBonnin 