### PR TITLE
Fix code facia-purger.

### DIFF
--- a/facia-purger/cloudformation/cloudformation.yml
+++ b/facia-purger/cloudformation/cloudformation.yml
@@ -72,6 +72,9 @@ Resources:
                     - Arn
             Runtime: java8
             Timeout: 30
+            Environment:
+                Variables:
+                    Stage: !Ref Stage
     NotificationTopic:
         Type: AWS::SNS::Topic
         Properties:

--- a/facia-purger/cloudformation/cloudformation.yml
+++ b/facia-purger/cloudformation/cloudformation.yml
@@ -12,6 +12,12 @@ Parameters:
             - CODE
             - PROD
         Default: CODE
+    FastlyServiceId:
+        Description: Id of service to purge
+        Type: String
+    FastlyAPIKey:
+        Description: API key with purge writes for service with id FastlyServiceId
+        Type: String
     DeployBucket:
         Description: Bucket where RiffRaff uploads artifacts on deploy
         Type: String
@@ -75,6 +81,8 @@ Resources:
             Environment:
                 Variables:
                     Stage: !Ref Stage
+                    FastlyAPIKey: !Ref FastlyAPIKey
+                    FastlyServiceId: !Ref FastlyServiceId
     NotificationTopic:
         Type: AWS::SNS::Topic
         Properties:

--- a/facia-purger/src/main/scala/com/gu/purge/facia/Config.scala
+++ b/facia-purger/src/main/scala/com/gu/purge/facia/Config.scala
@@ -1,48 +1,19 @@
 package com.gu.purge.facia
 
-import java.util.Properties
-
-import scala.util.Try
-import com.amazonaws.auth.profile._
-import com.amazonaws.auth.{ AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider, InstanceProfileCredentialsProvider, SystemPropertiesCredentialsProvider }
-import com.amazonaws.regions.Regions
-import com.amazonaws.services.s3.AmazonS3Client
-
 case class Config(fastlyServiceId: String, fastlyApiKey: String)
 
 object Config extends Logging {
 
-  val credentialsProviderChain = new AWSCredentialsProviderChain(
-    new EnvironmentVariableCredentialsProvider,
-    new SystemPropertiesCredentialsProvider,
-    new ProfileCredentialsProvider("frontend"),
-    new InstanceProfileCredentialsProvider
-  )
-
-  val s3: AmazonS3Client = new AmazonS3Client(credentialsProviderChain).withRegion(Regions.EU_WEST_1)
-
   def load(stage: String): Config = {
     log.info("Loading facia-purger config...")
-    val properties = loadProperties("aws-frontend-store", s"$stage/config/facia-purger.properties") getOrElse sys.error("Could not load config file from s3. This lambda will not run.")
 
-    val fastlyServiceId = getMandatoryConfig(properties, "fastly.serviceId")
-    log.debug(s"Fastly service ID = $fastlyServiceId")
+    val config = for {
+      fastlyApiKey <- Option(System.getenv("FastlyAPIKey"))
+      fastlyServiceId <- Option(System.getenv("FastlyServiceId"))
+    } yield {
+      Config(fastlyServiceId, fastlyApiKey)
+    }
 
-    val fastlyApiKey = getMandatoryConfig(properties, "fastly.apiKey")
-    log.debug(s"Fastly API key = ${fastlyApiKey.take(3)}...")
-
-    Config(fastlyServiceId, fastlyApiKey)
+    config.getOrElse(sys.error("Missing environment variable - FastlyAPIKey & FastlyServiceId must be provided"))
   }
-
-  private def loadProperties(bucket: String, key: String): Try[Properties] = {
-    val inputStream = s3.getObject(bucket, key).getObjectContent()
-    val properties: Properties = new Properties()
-    val result = Try(properties.load(inputStream)).map(_ => properties)
-    inputStream.close()
-    result
-  }
-
-  private def getMandatoryConfig(config: Properties, key: String) =
-    Option(config.getProperty(key)) getOrElse sys.error(s"''$key' property missing.")
-
 }

--- a/facia-purger/src/main/scala/com/gu/purge/facia/Config.scala
+++ b/facia-purger/src/main/scala/com/gu/purge/facia/Config.scala
@@ -4,7 +4,7 @@ import java.util.Properties
 
 import scala.util.Try
 import com.amazonaws.auth.profile._
-import com.amazonaws.auth.{AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider, InstanceProfileCredentialsProvider, SystemPropertiesCredentialsProvider}
+import com.amazonaws.auth.{ AWSCredentialsProviderChain, EnvironmentVariableCredentialsProvider, InstanceProfileCredentialsProvider, SystemPropertiesCredentialsProvider }
 import com.amazonaws.regions.Regions
 import com.amazonaws.services.s3.AmazonS3Client
 

--- a/facia-purger/src/main/scala/com/gu/purge/facia/FrontsS3PathParser.scala
+++ b/facia-purger/src/main/scala/com/gu/purge/facia/FrontsS3PathParser.scala
@@ -20,10 +20,9 @@ class FrontsS3PathParser(stage: String, val input: ParserInput) extends Parser w
 
   def run(): Option[String] = expr.run() match {
     case Success(matched) => Some(matched)
-    case x => {
+    case x =>
       log.error(s"error: $x, input: ${input.toString}")
       None
-    }
   }
 }
 

--- a/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
+++ b/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
@@ -26,6 +26,7 @@ class Lambda() extends RequestHandler[S3Event, Boolean] with Logging {
     log.debug(s"Processing ${entities.size} updated entities ...")
 
     entities.forall { entity =>
+      log.info(s"debug path log: ${entity.getObject.getKey}" )
       new FrontsS3PathParser(stage, entity.getObject.getKey)
         .run()
         .exists(sendPurgeRequest(_, config))
@@ -53,7 +54,7 @@ class Lambda() extends RequestHandler[S3Event, Boolean] with Logging {
       .post(EmptyJsonBody)
       .build()
 
-    if (stage == "PROD" || stage =="CODE") {
+    if (stage == "PROD" || stage == "CODE") {
       val response = httpClient.newCall(request).execute()
       log.info(s"Sent purge request for content with ID [$contentId]. Response from Fastly API: [${response.code}] [${response.body.string}]")
       response.code == 200

--- a/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
+++ b/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
@@ -10,7 +10,7 @@ import scala.collection.JavaConverters._
 
 class Lambda() extends RequestHandler[S3Event, Boolean] with Logging {
 
-  var stage = Option(System.getenv("Stage")).getOrElse("PROD")
+  var stage = Option(System.getenv("Stage")).getOrElse("DEV")
   private lazy val httpClient = new OkHttpClient()
 
   override def handleRequest(event: S3Event, context: Context) = {

--- a/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
+++ b/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
@@ -10,7 +10,7 @@ import scala.collection.JavaConverters._
 
 class Lambda() extends RequestHandler[S3Event, Boolean] with Logging {
 
-  var stage = "PROD"
+  var stage = Option(System.getenv("Stage")).getOrElse("PROD")
   private lazy val httpClient = new OkHttpClient()
 
   override def handleRequest(event: S3Event, context: Context) = {


### PR DESCRIPTION
The facia-purger lambda was previously hard coded to use PROD as the stage. This fixes that, and moves config from a file in S3 into environment variables, which simplifies the config code quite a bit, and saves messing around with S3 files when trying to update the config. As part of this I also needed to generate a new fastly API key. 