### PR TITLE
Move into VPC and modernise cloudformation

### DIFF
--- a/facia-purger/cloudformation/cloudformation.yml
+++ b/facia-purger/cloudformation/cloudformation.yml
@@ -1,128 +1,140 @@
 AWSTemplateFormatVersion: 2010-09-09
 Description: Facia purger lambda
 Parameters:
-    PackageName:
-        Description: Lambda name
-        Type: String
-        Default: facia-purger
-    Stage:
-        Description: Stage name
-        Type: String
-        AllowedValues:
-            - CODE
-            - PROD
-        Default: CODE
-    FastlyServiceId:
-        Description: Id of service to purge
-        Type: String
-    FastlyAPIKey:
-        Description: API key with purge writes for service with id FastlyServiceId
-        Type: String
-    DeployBucket:
-        Description: Bucket where RiffRaff uploads artifacts on deploy
-        Type: String
-    EmailRecipient:
-        Description: The email address to send alarm notifications to
-        Type: String
+  PackageName:
+    Description: Lambda name
+    Type: String
+    Default: facia-purger
+  Stage:
+    Description: Stage name
+    Type: String
+    AllowedValues:
+      - CODE
+      - PROD
+    Default: CODE
+  FastlyServiceId:
+    Description: Id of service to purge
+    Type: String
+  FastlyAPIKey:
+    Description: API key with purge writes for service with id FastlyServiceId
+    Type: String
+  DeployBucket:
+    Description: Bucket where RiffRaff uploads artifacts on deploy
+    Type: String
+  EmailRecipient:
+    Description: The email address to send alarm notifications to
+    Type: String
+  PrivateSubnets:
+    Type: List<AWS::EC2::Subnet::Id>
+    Description: Private subnets of vpc
+  VPC:
+    Type: AWS::EC2::VPC::Id
+    Description: VPC to deploy into
 Resources:
-    ExecutionRole:
-        Type: AWS::IAM::Role
-        Properties:
-            AssumeRolePolicyDocument:
-                Statement:
-                    - Effect: Allow
-                      Principal:
-                          Service:
-                              - lambda.amazonaws.com
-                      Action: sts:AssumeRole
-            Path: /
-            Policies:
-                - PolicyName: logs
-                  PolicyDocument:
-                      Statement:
-                          Effect: Allow
-                          Action:
-                              - logs:CreateLogGroup
-                              - logs:CreateLogStream
-                              - logs:PutLogEvents
-                          Resource: arn:aws:logs:*:*:*
-                - PolicyName: s3
-                  PolicyDocument:
-                      Statement:
-                          Effect: Allow
-                          Action:
-                              - s3:GetObject
-                          Resource: arn:aws:s3:::aws-frontend-store/*
-    Lambda:
-        Type: AWS::Lambda::Function
-        Properties:
-            Code:
-                S3Bucket:
-                    Ref: DeployBucket
-                S3Key:
-                    "Fn::Join":
-                        - /
-                        - - frontend
-                          - Ref: Stage
-                          - Ref: PackageName
-                          - "Fn::Join":
-                              - ""
-                              - - Ref: PackageName
-                                - .jar
-            Description: Purge fastly after a facia change event from an S3 bucket
-            Handler: com.gu.purge.facia.Lambda
-            MemorySize: 512
-            Role:
-                "Fn::GetAtt":
-                    - ExecutionRole
-                    - Arn
-            Runtime: java8
-            Timeout: 30
-            Environment:
-                Variables:
-                    Stage: !Ref Stage
-                    FastlyAPIKey: !Ref FastlyAPIKey
-                    FastlyServiceId: !Ref FastlyServiceId
-    NotificationTopic:
-        Type: AWS::SNS::Topic
-        Properties:
-            Subscription:
-                - Protocol: email
-                  Endpoint:
-                      Ref: EmailRecipient
-    InvocationAlarm:
-        Type: AWS::CloudWatch::Alarm
-        Properties:
-            InsufficientDataActions:
-                - Ref: NotificationTopic
-            AlarmDescription: Notify if there are less than 5 invocations over last 5 minutes or there is insufficient data (i.e. no invocations)
-            ComparisonOperator: LessThanOrEqualToThreshold
-            Dimensions:
-                - Name: FunctionName
-                  Value:
-                      Ref: Lambda
-            EvaluationPeriods: 1
-            MetricName: Invocations
-            Namespace: AWS/Lambda
-            Period: 3600
-            Statistic: Sum
-            Threshold: 0
-            Unit: Count
-    ErrorAlarm:
-        Type: AWS::CloudWatch::Alarm
-        Properties:
-            AlarmActions:
-                - Ref: NotificationTopic
-            AlarmDescription: Notify if there are more than 20 errors over last 5 minutes
-            ComparisonOperator: GreaterThanOrEqualToThreshold
-            Dimensions:
-                - Name: FunctionName
-                  Value:
-                      Ref: Lambda
-            EvaluationPeriods: 1
-            MetricName: Errors
-            Namespace: AWS/Lambda
-            Period: 300
-            Statistic: Sum
-            Threshold: 20
-            Unit: Count
+  ExecutionRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service:
+                - lambda.amazonaws.com
+            Action: sts:AssumeRole
+      Path: /
+      Policies:
+        - PolicyName: logs
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - logs:CreateLogGroup
+                - logs:CreateLogStream
+                - logs:PutLogEvents
+              Resource: arn:aws:logs:*:*:*
+        - PolicyName: s3
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - s3:GetObject
+              Resource: arn:aws:s3:::aws-frontend-store/*
+        - PolicyName: network-interfaces
+          PolicyDocument:
+            Statement:
+              Effect: Allow
+              Action:
+                - ec2:DescribeNetworkInterfaces
+                - ec2:CreateNetworkInterface
+                - ec2:DeleteNetworkInterface
+              Resource: "*"
+  Lambda:
+    Type: AWS::Lambda::Function
+    Properties:
+      Code:
+        S3Bucket: !Ref DeployBucket
+        S3Key: !Sub "frontend/${Stage}/${PackageName}/${PackageName}.jar"
+      Description: Purge fastly after a facia change event from an S3 bucket
+      Handler: com.gu.purge.facia.Lambda
+      MemorySize: 512
+      Role: !GetAtt ExecutionRole.Arn
+      Runtime: java8
+      Timeout: 30
+      Environment:
+        Variables:
+          Stage: !Ref Stage
+          FastlyAPIKey: !Ref FastlyAPIKey
+          FastlyServiceId: !Ref FastlyServiceId
+  NotificationTopic:
+    Type: AWS::SNS::Topic
+    Properties:
+      Subscription:
+        - Protocol: email
+          Endpoint:
+            Ref: EmailRecipient
+  InvocationAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      InsufficientDataActions:
+        - Ref: NotificationTopic
+      AlarmDescription: Notify if there are less than 5 invocations over last 5 minutes or there is insufficient data (i.e. no invocations)
+      ComparisonOperator: LessThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value:
+            Ref: Lambda
+      EvaluationPeriods: 1
+      MetricName: Invocations
+      Namespace: AWS/Lambda
+      Period: 3600
+      Statistic: Sum
+      Threshold: 0
+      Unit: Count
+  ErrorAlarm:
+    Type: AWS::CloudWatch::Alarm
+    Properties:
+      AlarmActions:
+        - Ref: NotificationTopic
+      AlarmDescription: Notify if there are more than 20 errors over last 5 minutes
+      ComparisonOperator: GreaterThanOrEqualToThreshold
+      Dimensions:
+        - Name: FunctionName
+          Value:
+            Ref: Lambda
+      EvaluationPeriods: 1
+      MetricName: Errors
+      Namespace: AWS/Lambda
+      Period: 300
+      Statistic: Sum
+      Threshold: 20
+      Unit: Count
+  LambdaSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: Security group for github lambda - allow access to fastly
+      VpcId: !Ref VPC
+      SecurityGroupEgress:
+        CidrIp: 0.0.0.0/0
+        IpProtocol: tcp
+        FromPort: 443
+        ToPort: 443

--- a/facia-purger/cloudformation/cloudformation.yml
+++ b/facia-purger/cloudformation/cloudformation.yml
@@ -85,6 +85,10 @@ Resources:
           Stage: !Ref Stage
           FastlyAPIKey: !Ref FastlyAPIKey
           FastlyServiceId: !Ref FastlyServiceId
+      VpcConfig:
+        SubnetIds: !Ref PrivateSubnets
+        SecurityGroupIds:
+          - !Ref LambdaSecurityGroup
   NotificationTopic:
     Type: AWS::SNS::Topic
     Properties:


### PR DESCRIPTION
This looks awful because I changed the indentation from 4 to 2 spaces, sorry. But the only significant change is in the second commit - which moves the lambda in to the VPC. I've tested this on CODE. I also used !Sub in a few places to get rid of awful JSON-era joins.