### PR TITLE
Update cloudformation to reflect prod resources

### DIFF
--- a/facia-purger/cloudformation.yaml
+++ b/facia-purger/cloudformation.yaml
@@ -25,12 +25,6 @@ Parameters:
   EmailRecipient:
     Description: The email address to send alarm notifications to
     Type: String
-  PrivateSubnets:
-    Type: List<AWS::EC2::Subnet::Id>
-    Description: Private subnets of vpc
-  VPC:
-    Type: AWS::EC2::VPC::Id
-    Description: VPC to deploy into
 Resources:
   ExecutionRole:
     Type: AWS::IAM::Role
@@ -86,10 +80,6 @@ Resources:
           Stage: !Ref Stage
           FastlyAPIKey: !Ref FastlyAPIKey
           FastlyServiceId: !Ref FastlyServiceId
-      VpcConfig:
-        SubnetIds: !Ref PrivateSubnets
-        SecurityGroupIds:
-          - !Ref LambdaSecurityGroup
   NotificationTopic:
     Type: AWS::SNS::Topic
     Properties:
@@ -133,13 +123,3 @@ Resources:
       Statistic: Sum
       Threshold: 20
       Unit: Count
-  LambdaSecurityGroup:
-    Type: AWS::EC2::SecurityGroup
-    Properties:
-      GroupDescription: Security group for github lambda - allow access to fastly
-      VpcId: !Ref VPC
-      SecurityGroupEgress:
-        CidrIp: 0.0.0.0/0
-        IpProtocol: tcp
-        FromPort: 443
-        ToPort: 443


### PR DESCRIPTION
Resources for the facia purger lambda differed between code and prod. The deployment to code was successful because all resources defined in the cloudformation existed, however deployment to prod failed as some new params (for prod, at least) didn't have defaults.
Ref: https://riffraff.gutools.co.uk/deployment/view/ad065cfe-d2f3-4782-8d92-f4ea24a802bd

This change updates the cloudformation to ensure the resources created match the prod env.

From my understanding, lambdas don't need to operate in a vpc to be secure, so I think this is ok.

NB: lambda in prod isn't included in a vpc and does not have any security groups attached:
<img width="1647" alt="Screenshot 2021-09-08 at 14 28 44" src="https://user-images.githubusercontent.com/45561419/132518385-96c600cd-76f1-40eb-8e58-c6786097931e.png">

