### PR TITLE
Bump `okhttp` and `log4j`

### DIFF
--- a/facia-purger/build.sbt
+++ b/facia-purger/build.sbt
@@ -3,7 +3,7 @@ import sbtassembly.Log4j2MergeStrategy
 name := "facia-purger"
 
 scalaVersion := "2.11.8"
-val log4jVersion = "2.16.0"
+val log4jVersion = "2.17.1"
 
 organization := "com.gu"
 description := "Lambda for purging Fastly cache based on s3 events"
@@ -16,7 +16,7 @@ libraryDependencies ++= Seq(
   "org.apache.logging.log4j" % "log4j-api" % log4jVersion,
   "org.apache.logging.log4j" % "log4j-core" % log4jVersion,
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jVersion,
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.4.0",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.1",
   "org.scalatest" %% "scalatest" % "2.2.2" % "test",
   "org.mockito" % "mockito-all" % "1.9.5" % "test"
   )

--- a/facia-purger/build.sbt
+++ b/facia-purger/build.sbt
@@ -33,6 +33,7 @@ riffRaffArtifactResources += (baseDirectory.value / "riff-raff.yaml" -> "riff-ra
 
 assembly / assemblyMergeStrategy := {
   case PathList(ps @ _*) if ps.last == "Log4j2Plugins.dat" => Log4j2MergeStrategy.plugincache
+  case PathList(ps @ _*) if ps.last == "module-info.class" => MergeStrategy.discard
   case x =>
     val oldStrategy = (assembly / assemblyMergeStrategy).value
     oldStrategy(x)

--- a/facia-purger/build.sbt
+++ b/facia-purger/build.sbt
@@ -11,7 +11,7 @@ description := "Lambda for purging Fastly cache based on s3 events"
 libraryDependencies ++= Seq(
   "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
   "com.amazonaws" % "aws-lambda-java-events" % "1.3.0",
-  "com.squareup.okhttp3" % "okhttp" % "3.2.0",
+  "com.squareup.okhttp3" % "okhttp" % "4.9.2",
   "org.parboiled" %% "parboiled" % "2.1.3",
   "org.apache.logging.log4j" % "log4j-api" % log4jVersion,
   "org.apache.logging.log4j" % "log4j-core" % log4jVersion,

--- a/facia-purger/build.sbt
+++ b/facia-purger/build.sbt
@@ -33,6 +33,8 @@ riffRaffArtifactResources += (baseDirectory.value / "riff-raff.yaml" -> "riff-ra
 
 assembly / assemblyMergeStrategy := {
   case PathList(ps @ _*) if ps.last == "Log4j2Plugins.dat" => Log4j2MergeStrategy.plugincache
+  // https://stackoverflow.com/a/55557287
+  // Okhttp and log4j both have module-info files, but we don't actually need either file.
   case PathList(ps @ _*) if ps.last == "module-info.class" => MergeStrategy.discard
   case x =>
     val oldStrategy = (assembly / assemblyMergeStrategy).value

--- a/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
+++ b/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
@@ -35,7 +35,7 @@ class Lambda() extends RequestHandler[S3Event, Boolean] with Logging {
 
   // OkHttp requires a media type even for an empty POST body
   private val EmptyJsonBody: RequestBody =
-    RequestBody.create(MediaType.parse("application/json; charset=utf-8"), "")
+    RequestBody.create("", MediaType.parse("application/json; charset=utf-8"))
 
   /**
    * Send a soft purge request to Fastly API.


### PR DESCRIPTION
## What does this change?

Bumps `okhttp` to 4.9.2 (and resolves deprecation notice of `RequestBody.create`)
Bumps `log4j` to 2.17.1
