### PR TITLE
chore: Bump aws-lambda-java-events to 3.11.0

### DIFF
--- a/facia-purger/build.sbt
+++ b/facia-purger/build.sbt
@@ -9,8 +9,8 @@ organization := "com.gu"
 description := "Lambda for purging Fastly cache based on s3 events"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-lambda-java-core" % "1.1.0",
-  "com.amazonaws" % "aws-lambda-java-events" % "1.3.0",
+  "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
+  "com.amazonaws" % "aws-lambda-java-events" % "3.11.0",
   "com.squareup.okhttp3" % "okhttp" % "4.9.2",
   "org.parboiled" %% "parboiled" % "2.4.1",
   "org.apache.logging.log4j" % "log4j-api" % log4jVersion,
@@ -18,8 +18,9 @@ libraryDependencies ++= Seq(
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jVersion,
   "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.1",
   "org.scalatest" %% "scalatest" % "3.2.15" % "test",
-  "org.mockito" % "mockito-all" % "1.9.5" % "test"
-  )
+  "org.mockito" % "mockito-all" % "1.9.5" % "test",
+  "commons-codec" % "commons-codec" % "1.15"
+)
   
 def env(key: String): Option[String] = Option(System.getenv(key))
 

--- a/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
+++ b/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
@@ -2,7 +2,7 @@ package com.gu.purge.facia
 
 import com.amazonaws.services.lambda.runtime.{ Context, RequestHandler }
 import com.amazonaws.services.lambda.runtime.events.S3Event
-import com.amazonaws.services.s3.event.S3EventNotification.S3Entity
+import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification.S3Entity
 import okhttp3._
 import org.apache.commons.codec.digest.DigestUtils
 

--- a/facia-purger/src/test/scala/com/gu/purge/facia/LambdaTest.scala
+++ b/facia-purger/src/test/scala/com/gu/purge/facia/LambdaTest.scala
@@ -1,7 +1,7 @@
 package com.gu.purge.facia
 
 import com.amazonaws.services.lambda.runtime.events.S3Event
-import com.amazonaws.services.s3.event.S3EventNotification._
+import com.amazonaws.services.lambda.runtime.events.models.s3.S3EventNotification._
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.should.Matchers._
 
@@ -14,12 +14,12 @@ class LambdaTest extends AnyFlatSpec {
   val resp = new ResponseElementsEntity("s", "d")
   val user = new UserIdentityEntity("f")
   val bucket = new S3BucketEntity("g", user, "h")
-  val obj = new S3ObjectEntity(key, 0L, "j", "k")
+  val obj = new S3ObjectEntity(key, 0L, "j", "k", null)
   val s3 = new S3Entity("l", bucket, obj, "q")
   val record: S3EventNotificationRecord = new S3EventNotificationRecord("w", "e", "r", "2010-06-30T01:20+02:00", "y", req, resp, s3, user)
 
   val invalidKey = "NOTDEV/frontsapy/prossed/dead/au/capi/prossed.yml"
-  val invalidObj = new S3ObjectEntity(invalidKey, 0L, "j", "k")
+  val invalidObj = new S3ObjectEntity(invalidKey, 0L, "j", "k", null)
   val invalidS3 = new S3Entity("l", bucket, invalidObj, "q")
   val invalidRecord: S3EventNotificationRecord = new S3EventNotificationRecord("w", "e", "r", "2010-06-30T01:20+02:00", "y", req, resp, invalidS3, user)
 


### PR DESCRIPTION
## What does this change?

Bumps `aws-lambda-java-events` to `3.11.0` in `facia-purger` lambda.