### PR TITLE
gitignore metals-generated directories and files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ target
 .metals
 .bsp
 build.properties
+.bloop
+**/project/metals.sbt
 
 # Miscellaneous
 *.iml


### PR DESCRIPTION
## What does this change?

- Ignores files generated by `metals`, making the codebase easier to work with in VSCode

