### PR TITLE
Migrate backup-paramater-store to gha

### DIFF
--- a/.github/workflows/buildBackupParamaterStore.yaml
+++ b/.github/workflows/buildBackupParamaterStore.yaml
@@ -10,8 +10,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v2
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1

--- a/.github/workflows/buildFaciaPurger.yaml
+++ b/.github/workflows/buildFaciaPurger.yaml
@@ -11,8 +11,8 @@ jobs:
       id-token: write
       contents: read
     steps:
-      - uses: actions/checkout@v2
-      - uses: aws-actions/configure-aws-credentials@v1
+      - uses: actions/checkout@v4
+      - uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           aws-region: eu-west-1


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This adds a workflow for the backup-paramater-store and changes the workflows to only run on push to each projects respective directories.

Paused the `backup-parameter-store` project in TeamCity

Resolves https://github.com/guardian/frontend-lambda/issues/47

