### PR TITLE
Fix deployment for `backup-parameter-store` lambda

### DIFF
--- a/.github/workflows/buildBackupParamaterStore.yaml
+++ b/.github/workflows/buildBackupParamaterStore.yaml
@@ -31,6 +31,7 @@ jobs:
           configPath: backup-parameter-store/riff-raff.yaml
           buildNumberOffset: 1118
           contentDirectories: |
+            backup-parameter-store-cfn:
+              - backup-parameter-store/cfn.yaml
             backup-parameter-store:
               - backup-parameter-store/backup-parameter-store.jar
-              - backup-parameter-store/cfn.yaml

--- a/backup-parameter-store/src/main/scala/com/gu/backupparameterstore/Lambda.scala
+++ b/backup-parameter-store/src/main/scala/com/gu/backupparameterstore/Lambda.scala
@@ -21,7 +21,7 @@ object Lambda extends LazyLogging {
   val backupService = new BackupService(new ParameterStore, new S3, env)
 
   def handler(lambdaInput: ConfigEvent, context: Context): Unit = {
-    logger.info(s"Starting up $env")
+    logger.info(s"Starting $env")
     backupService.backupParameterStore()
   }
 

--- a/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
+++ b/facia-purger/src/main/scala/com/gu/purge/facia/Lambda.scala
@@ -14,7 +14,7 @@ class Lambda() extends RequestHandler[S3Event, Boolean] with Logging {
   private lazy val httpClient = new OkHttpClient()
 
   override def handleRequest(event: S3Event, context: Context) = {
-    log.debug(s"Facia-purger lambda is starting up")
+    log.debug(s"Facia-purger lambda starting up")
     val config = Config.load(stage)
 
     processS3Event(event, config)


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Correct contentDirectories path and fixes `backup-parameter-store` deployment

## Before
<img width="952" alt="image" src="https://github.com/guardian/frontend-lambda/assets/110032454/d13a8669-af6f-407e-80f3-1dbea3bcd938">

## After
![image](https://github.com/guardian/frontend-lambda/assets/19683595/d9f4db62-4a19-4992-af19-cb00a10177a1)


