### PR TITLE
Use `java11` runtime for `backup-parameter-store` lambda

### DIFF
--- a/backup-parameter-store/build.sbt
+++ b/backup-parameter-store/build.sbt
@@ -5,14 +5,20 @@ organization := "com.gu"
 
 description:= "Backs up parameter store properties. To be executed on an interval"
 
-scalaVersion := "2.13.10"
+scalaVersion := "2.13.12"
 
 scalacOptions ++= Seq(
   "-deprecation",
   "-encoding", "UTF-8",
-  "-release:8",
+  "-release:11",
   "-Ywarn-dead-code"
 )
+
+initialize := {
+  val _ = initialize.value
+  assert(sys.props("java.specification.version") == "11",
+    "Java 11 is required for this project.")
+}
 
 val awsVersion = "1.12.415"
 

--- a/backup-parameter-store/cfn.yaml
+++ b/backup-parameter-store/cfn.yaml
@@ -91,7 +91,7 @@ Resources:
       Handler: com.gu.backupparameterstore.Lambda::handler
       MemorySize: 512
       Role: !GetAtt ExecutionRole.Arn
-      Runtime: java8
+      Runtime: java11
       Timeout: 300
 
 

--- a/backup-parameter-store/project/build.properties
+++ b/backup-parameter-store/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.2
+sbt.version=1.9.8


### PR DESCRIPTION
Closes https://github.com/guardian/frontend-lambda/issues/57
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Updates lambda to use `java11` runtime. [AWS is deprecating `java8`](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) from the 8th of January 2023.


<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

Ran in CODE successfully. It uses Java 11 runtime.

<img width="1489" alt="image" src="https://github.com/guardian/frontend-lambda/assets/19683595/f4085e52-87be-4431-825f-e2d1564de09e"> <br>

### Kibana logs

<img width="1335" alt="image" src="https://github.com/guardian/frontend-lambda/assets/19683595/9dc2e822-acf7-4724-8bee-af3c79c520b8">


### Cloudwatch logs

<img width="1043" alt="image" src="https://github.com/guardian/frontend-lambda/assets/19683595/9204c619-cc5f-4102-990f-8403988493a9">

