### PR TITLE
Use the default artifacts bucket for backup-parameter-store lambda

### DIFF
--- a/backup-parameter-store/riff-raff.yaml
+++ b/backup-parameter-store/riff-raff.yaml
@@ -5,7 +5,6 @@ deployments:
   backup-parameter-store:
     type: aws-lambda
     parameters:
-      bucket: aws-frontend-artifacts
       fileName: backup-parameter-store.jar
       functions:
         PROD:


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Removes bucket name from `backup-parameter-store/riff-raff.yaml`.

Aligns with the [recommendation](https://github.com/guardian/recommendations/blob/f6038a38e4b65d17312382772afc0ebf7da17f97/github.md#private-information) about bucket names. Also, makes Riff-Raff warning disappear.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

### Before
<img width="1183" alt="image" src="https://github.com/guardian/frontend-lambda/assets/19683595/63a8d8ed-03b4-4c78-9a31-429835759a5c">

### After
Still uploads the artifact to the correct bucket. No warning this time.

<img width="1181" alt="image" src="https://github.com/guardian/frontend-lambda/assets/19683595/0057d3fc-f408-40d0-9a5a-1d4cf63323fb">
