### PR TITLE
Bump actions-riff-raff version to v4

### DIFF
--- a/.github/workflows/buildBackupParamaterStore.yaml
+++ b/.github/workflows/buildBackupParamaterStore.yaml
@@ -2,7 +2,9 @@ name: Build Backup Parameter Store
 on:
   push:
     paths:
+      - '.github/**'
       - 'backup-parameter-store/**'
+
 jobs:
   backup-parameter-store:
     runs-on: ubuntu-latest

--- a/.github/workflows/buildFaciaPurger.yaml
+++ b/.github/workflows/buildFaciaPurger.yaml
@@ -2,9 +2,11 @@ name: Build Facia Purger
 on:
   push:
     paths:
+      -  '.github/**'
       - 'cdk/**'
       - 'facia-purger/**'
   workflow_dispatch:
+
 jobs:
   facia-purger:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## What is the value of this and can you measure success?

Upgrades to use the latest version of `guardian/actions-riff-raff`.

Part of https://github.com/guardian/dotcom-rendering/issues/10600

## What does this change?

- Adds write permissions for pull requests and adds `githubToken` to the job step as [required in the major version bump for v3](https://github.com/guardian/actions-riff-raff/releases/tag/v3.0.0)
- Removes step to configure AWS credentials and uses the AWS role ARN directly in the riff-raff action [as required in the major bump for v4](https://github.com/guardian/actions-riff-raff/releases/tag/v4)

## Testing

Have checked that the new builds appear in Riffraff