### PR TITLE
Facia Purger: Upgrade libraries to their latest versions

### DIFF
--- a/facia-purger/build.sbt
+++ b/facia-purger/build.sbt
@@ -3,20 +3,20 @@ import sbtassembly.Log4j2MergeStrategy
 name := "facia-purger"
 
 scalaVersion := "2.13.10"
-val log4jVersion = "2.17.1"
+val log4jVersion = "2.25.2"
 
 organization := "com.gu"
 description := "Lambda for purging Fastly cache based on s3 events"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-lambda-java-core" % "1.2.2",
-  "com.amazonaws" % "aws-lambda-java-events" % "3.11.0",
+  "com.amazonaws" % "aws-lambda-java-core" % "1.4.0",
+  "com.amazonaws" % "aws-lambda-java-events" % "3.16.1",
   "com.squareup.okhttp3" % "okhttp" % "4.9.2",
   "org.parboiled" %% "parboiled" % "2.4.1",
   "org.apache.logging.log4j" % "log4j-api" % log4jVersion,
   "org.apache.logging.log4j" % "log4j-core" % log4jVersion,
   "org.apache.logging.log4j" % "log4j-slf4j-impl" % log4jVersion,
-  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.5.1",
+  "com.amazonaws" % "aws-lambda-java-log4j2" % "1.6.0",
   "org.scalatest" %% "scalatest" % "3.2.15" % "test",
   "org.mockito" % "mockito-all" % "1.9.5" % "test",
   "commons-codec" % "commons-codec" % "1.15"


### PR DESCRIPTION
Closes https://github.com/guardian/frontend-lambda/issues/68

<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Update the following libraries to their latest version:

* `aws-lambda-java-core`
* `aws-lambda-java-events`
* `aws-lambda-java-log4j2`

There is no AWS SDK code in facia-purger lambda, the three libraries above are SDK-agnostic. 


## How to test
Deployed in CODE and the lambda is still purging the cache for updated fronts

<img width="1699" height="697" alt="image" src="https://github.com/user-attachments/assets/54114604-f371-4ce4-9137-106fc340ebad" />


<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->
