### PR TITLE
Fix Scala Steward run: Allow sbt to run with later Java versions

### DIFF
--- a/backup-parameter-store/build.sbt
+++ b/backup-parameter-store/build.sbt
@@ -5,7 +5,7 @@ organization := "com.gu"
 
 description:= "Backs up parameter store properties. To be executed on an interval"
 
-scalaVersion := "2.13.17"
+scalaVersion := "2.13.18"
 
 scalacOptions ++= Seq(
   "-deprecation",
@@ -13,12 +13,6 @@ scalacOptions ++= Seq(
   "-release:11",
   "-Ywarn-dead-code"
 )
-
-initialize := {
-  val _ = initialize.value
-  assert(sys.props("java.specification.version") == "11",
-    "Java 11 is required for this project.")
-}
 
 val awsVersion = "2.37.3"
 

--- a/facia-purger/build.sbt
+++ b/facia-purger/build.sbt
@@ -2,7 +2,7 @@ import sbtassembly.Log4j2MergeStrategy
 
 name := "facia-purger"
 
-scalaVersion := "2.13.10"
+scalaVersion := "2.13.18"
 val log4jVersion = "2.25.2"
 
 organization := "com.gu"


### PR DESCRIPTION
See:

* https://github.com/guardian/maintaining-scala-projects/issues/10

Note this project is already using `scalacOptions "-release:N"` as recommended, and the additional strict-match check of `java.specification.version` is troublesome.

This follows on from the previous fix in:

* https://github.com/guardian/frontend-lambda/pull/78

I would also suggest upgrading Java!

* https://github.com/guardian/maintaining-scala-projects/issues/23